### PR TITLE
Pangolin update rule

### DIFF
--- a/workflow/envs/pangolin.yaml
+++ b/workflow/envs/pangolin.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - pangolin =2.1.7
+  - pangolin =2.2.2

--- a/workflow/rules/strain_calling.smk
+++ b/workflow/rules/strain_calling.smk
@@ -95,6 +95,32 @@ rule plot_all_strains_kallisto:
         "../notebooks/plot-all-strains-kallisto.py.ipynb"
 
 
+rule update_pangolin_db:
+    output:
+        temp(touch("resources/pangolin-update.done")),
+    log:
+        "logs/pangolin/update.log",
+    conda:
+        "../envs/pangolin.yaml"
+    shell:
+        "(pangolin --update) > {log} 2>&1"
+
+
+rule pangolin:
+    input:
+        contigs="results/polished-contigs/{sample}.fasta",
+        update="resources/pangolin-update.done",
+    output:
+        "results/tables/strain-calls/{sample}.strains.pangolin.csv",
+    log:
+        "logs/pangolin/{sample}.log",
+    threads: 8
+    conda:
+        "../envs/pangolin.yaml"
+    shell:
+        "pangolin {input.contigs} --threads {threads} --outfile {output} > {log} 2>&1"
+
+
 rule plot_strains_pangolin:
     input:
         "results/tables/strain-calls/{sample}.strains.pangolin.csv",
@@ -111,20 +137,6 @@ rule plot_strains_pangolin:
         "../envs/python.yaml"
     notebook:
         "../notebooks/plot-strains-pangolin.py.ipynb"
-
-
-rule pangolin:
-    input:
-        "results/polished-contigs/{sample}.fasta",
-    output:
-        "results/tables/strain-calls/{sample}.strains.pangolin.csv",
-    log:
-        "logs/pangolin/{sample}.log",
-    threads: 8
-    conda:
-        "../envs/pangolin.yaml"
-    shell:
-        "pangolin {input} --outfile {output} > {log} 2>&1"
 
 
 rule plot_all_strains_pangolin:


### PR DESCRIPTION
This PR introduces rule, which should update pangolin every run by executing `pangolin --update`.

It could be considered to remove the version number in the yaml environment to always use the latest pangolin version. However, this would of course speak against a reproducible result of the workflow.