### PR TITLE
save results rule

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,11 +5,12 @@ pepfile: config/pep/config.yaml
 
 
 data-handling:
-  # path of incoming data
+  # path of incoming data, which is moved to the data directory
   incoming: ../incoming/
   # path to store data in the workflow
   data: data/
-  # path to archive data from incoming to
+  # path to archive data from incoming and 
+  # the results from the latest run to
   archive: ../archive/
 
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -25,16 +25,28 @@ include: "rules/generate_output.smk"
 
 rule save_latest_run:
     input:
-        lambda checkpoints: with checkpoints.all.output.get(): "results/all.done",
+        expand(
+            "results/archive-indicator/{latest_run}.archived",
+            latest_run=get_latest_run_date(),
+        ),
+    output:
+        expand(
+            "".join(
+                (
+                    config["data-handling"]["archive"],
+                    "{latest_run}/results_{latest_run}.tar.gz",
+                )
+            ),
+            latest_run=get_latest_run_date(),
+        ),
     params:
-        archive = config["data-handling"]["archive"]
-        latest_run = get_latest_run_date()
+        latest_run=get_latest_run_date(),
     log:
-        "../logs/save-latest-run.log"
+        expand("logs/save-run/{latest_run}.log", latest_run=get_latest_run_date()),
     conda:
-        "../envs/unix.yaml"
+        "envs/unix.yaml"
     shell:
-        "tar -zcvf {params.archive}/{params.latest_run}/results_{params.latest_run}.tar.gz results/{params.latest_run}"
+        "tar -zcvf {output} results/{params.latest_run} 2> {log} 2>&1"
 
 
 checkpoint all:
@@ -83,7 +95,12 @@ checkpoint all:
             expand_wildcard=config["variant-calling"]["filters"],
         ),
     output:
-        temp(touch("results/all.done"))
+        touch(
+            expand(
+                "results/archive-indicator/{latest_run}.archived",
+                latest_run=get_latest_run_date(),
+            )
+        ),
 
 
 rule benchmark_strain_calling:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -23,7 +23,21 @@ include: "rules/benchmarking.smk"
 include: "rules/generate_output.smk"
 
 
-rule all:
+rule save_latest_run:
+    input:
+        lambda checkpoints: with checkpoints.all.output.get(): "results/all.done",
+    params:
+        archive = config["data-handling"]["archive"]
+        latest_run = get_latest_run_date()
+    log:
+        "../logs/save-latest-run.log"
+    conda:
+        "../envs/unix.yaml"
+    shell:
+        "tar -zcvf {params.archive}/{params.latest_run}/results_{params.latest_run}.tar.gz results/{params.latest_run}"
+
+
+checkpoint all:
     input:
         expand(
             "results/{date}/qc/multiqc.html", date=get_all_run_dates(),
@@ -68,6 +82,8 @@ rule all:
             zip_wildcard_2=get_samples() + ["all"] * len(get_all_run_dates()),
             expand_wildcard=config["variant-calling"]["filters"],
         ),
+    output:
+        temp(touch("results/all.done"))
 
 
 rule benchmark_strain_calling:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -52,6 +52,8 @@ def get_all_run_dates():
     sorted_list.sort()
     return sorted_list
 
+def get_latest_run_date():
+    return pep.sample_table["run_id"].max()
 
 def get_fastqs(wildcards, benchmark_prefix="benchmark-sample-"):
     if wildcards.sample.startswith(benchmark_prefix):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -52,8 +52,10 @@ def get_all_run_dates():
     sorted_list.sort()
     return sorted_list
 
+
 def get_latest_run_date():
     return pep.sample_table["run_id"].max()
+
 
 def get_fastqs(wildcards, benchmark_prefix="benchmark-sample-"):
     if wildcards.sample.startswith(benchmark_prefix):


### PR DESCRIPTION
Closes #61 

I've decided to use expand + a function instead of a wildcard to save the latest run results. This approach shouldn't overwrite results from older runs if something upstream changes. 

However, I somehow don't like the "style" to get an output of the all rule to save the results. Maybe checkpoints would be another option. If someone has an idea to realise the archiving of the results better, please feel free to contribute.