### PR TITLE
do not mark recalibrated read alignments as temporary

### DIFF
--- a/workflow/rules/read_mapping.smk
+++ b/workflow/rules/read_mapping.smk
@@ -79,7 +79,7 @@ rule samtools_calmd:
         aln="results/{date}/dedup/ref~{reference}/{sample}.bam",
         ref=get_reference(),
     output:
-        temp("results/{date}/recal/ref~{reference}/{sample}.bam"),
+        "results/{date}/recal/ref~{reference}/{sample}.bam",
     log:
         "logs/{date}/samtools-calmd/ref~{reference}/{sample}.log",
     params:


### PR DESCRIPTION
They are important to check if any problems occur.