### PR TITLE
Allow to configure the workflow for amplicon data

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Formatting
-        uses: github/super-linter@v3
+        uses: github/super-linter@v3.15.3
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master

--- a/.tests/config/config.yaml
+++ b/.tests/config/config.yaml
@@ -71,8 +71,8 @@ strain-calling:
 
 adapters:
   #  Illumina TruSeq adapters
-  illumina: "--adapter_sequence AGATCGGAAGAGCACACGTCTGAACTCCAGTCA --adapter_sequence_r2 AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
-
+  illumina-revelo: "--adapter_sequence AGATCGGAAGAGCACACGTCTGAACTCCAGTCA --adapter_sequence_r2 AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
+  illumina-nimagen: "--adapter_sequence GCGAATTTCGACGATCGTTGCATTAACTCGCGAA --adapter_sequence_r2 AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
 
 rki-output:
 # minimum contig length

--- a/.tests/config/pep/samples.csv
+++ b/.tests/config/pep/samples.csv
@@ -1,3 +1,3 @@
-sample_name,fq1,fq2,run_id
-a,data/ERR4861412_1.fastq.gz,data/ERR4861412_2.fastq.gz,2021-02-01
+sample_name,fq1,fq2,run_id,is_amplicon_data
+a,data/ERR4861412_1.fastq.gz,data/ERR4861412_2.fastq.gz,2021-01-01,0
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -71,7 +71,8 @@ rki-output:
 
 adapters:
   #  Illumina TruSeq adapters
-  illumina: "--adapter_sequence AGATCGGAAGAGCACACGTCTGAACTCCAGTCA --adapter_sequence_r2 AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
+  illumina-revelo: "--adapter_sequence AGATCGGAAGAGCACACGTCTGAACTCCAGTCA --adapter_sequence_r2 AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
+  illumina-nimagen: "--adapter_sequence GCGAATTTCGACGATCGTTGCATTAACTCGCGAA --adapter_sequence_r2 AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
 
 
 # NCBI reference sequences of non-SARS-CoV-2 coronavirus. 

--- a/config/pep/samples.csv
+++ b/config/pep/samples.csv
@@ -1,2 +1,2 @@
-sample_name,fq1,fq2,run_id
-a,data/ERR4861412_1.fastq.gz,data/ERR4861412_2.fastq.gz,2021-01-01
+sample_name,fq1,fq2,run_id,is_amplicon_data
+a,data/ERR4861412_1.fastq.gz,data/ERR4861412_2.fastq.gz,2021-01-01,0

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -55,12 +55,14 @@ rule save_latest_run:
 checkpoint all:
     input:
         expand(
-            "results/{date}/qc/multiqc.html", date=get_all_run_dates(),
+            "results/{date}/qc/multiqc.html",
+            date=get_all_run_dates(),
         ),
         expand("results/reports/{date}.zip", date=get_all_run_dates()),
         expand("results/rki/{date}_uk-essen_rki.fasta", date=get_all_run_dates()),
         expand(
-            "results/{date}/plots/all.strains.pangolin.svg", date=get_all_run_dates(),
+            "results/{date}/plots/all.strains.pangolin.svg",
+            date=get_all_run_dates(),
         ),
         expand(
             "results/{date}/plots/all.{mode}-strain.strains.kallisto.svg",
@@ -98,13 +100,16 @@ checkpoint all:
             expand_wildcard=config["variant-calling"]["filters"],
         ),
         expand(
-            "results/{date}/virologist/report.csv", date=get_all_run_dates(),
+            "results/{date}/virologist/report.csv",
+            date=get_all_run_dates(),
         ),
         expand(
-            "results/{date}/var_data/", date=get_all_run_dates(),
+            "results/{date}/var_data/",
+            date=get_all_run_dates(),
         ),
         expand(
-            "results/{date}/qc_data/", date=get_all_run_dates(),
+            "results/{date}/qc_data/",
+            date=get_all_run_dates(),
         ),
     output:
         touch(

--- a/workflow/envs/varlociraptor.yaml
+++ b/workflow/envs/varlociraptor.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - varlociraptor =2.6.1
+  - varlociraptor =2.6.4

--- a/workflow/envs/varlociraptor.yaml
+++ b/workflow/envs/varlociraptor.yaml
@@ -2,8 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-<<<<<<< HEAD
-  - varlociraptor =2.6.3
-=======
-  - varlociraptor =2.6.2
->>>>>>> 7976cf23303985045fa35c17abadd3bcfde979fe
+  - varlociraptor =2.6.1

--- a/workflow/envs/varlociraptor.yaml
+++ b/workflow/envs/varlociraptor.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - varlociraptor =2.6.1
+  - varlociraptor =2.6.3

--- a/workflow/envs/varlociraptor.yaml
+++ b/workflow/envs/varlociraptor.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - varlociraptor =2.6.4
+  - varlociraptor =2.6.5

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -7,6 +7,7 @@ VARTYPES = ["SNV", "MNV", "INS", "DEL", "REP"]
 
 
 BENCHMARK_PREFIX = "benchmark-sample-"
+NON_COV2_TEST_PREFIX = "non-cov2-"
 
 
 def get_samples():
@@ -69,9 +70,9 @@ def get_fastqs(wildcards):
             accession=accession,
             read=[1, 2],
         )
-    if wildcards.sample.startswith("non-cov2-"):
+    if wildcards.sample.startswith(NON_COV2_TEST_PREFIX):
         # this is for testing non-sars-cov2-genomes
-        accession = wildcards.sample[len("non-cov2-") :]
+        accession = wildcards.sample[len(NON_COV2_TEST_PREFIX) :]
         return expand(
             "resources/test-cases/{accession}/reads.{read}.fastq.gz",
             accession=accession,
@@ -317,7 +318,7 @@ def get_strain(path_to_pangolin_call):
 
 
 def is_amplicon_data(sample):
-    if sample.startswith(BENCHMARK_PREFIX):
+    if sample.startswith(BENCHMARK_PREFIX) or sample.startswith(NON_COV2_TEST_PREFIX):
         # benchmark data, not amplicon based
         return False
     sample = pep.sample_table.loc[sample]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -6,6 +6,9 @@ import pandas as pd
 VARTYPES = ["SNV", "MNV", "INS", "DEL", "REP"]
 
 
+BENCHMARK_PREFIX = "benchmark-sample-"
+
+
 def get_samples():
     return list(pep.sample_table["sample_name"].values)
 
@@ -57,10 +60,10 @@ def get_latest_run_date():
     return pep.sample_table["run_id"].max()
 
 
-def get_fastqs(wildcards, benchmark_prefix="benchmark-sample-"):
-    if wildcards.sample.startswith(benchmark_prefix):
+def get_fastqs(wildcards):
+    if wildcards.sample.startswith(BENCHMARK_PREFIX):
         # this is a simulated benchmark sample, do not look up FASTQs in the sample sheet
-        accession = wildcards.sample[len(benchmark_prefix) :]
+        accession = wildcards.sample[len(BENCHMARK_PREFIX) :]
         return expand(
             "resources/benchmarking/{accession}/reads.{read}.fastq.gz",
             accession=accession,
@@ -314,7 +317,10 @@ def get_strain(path_to_pangolin_call):
 
 
 def is_amplicon_data(sample):
-    sample = samples.loc[sample]
+    if sample.startswith(BENCHMARK_PREFIX):
+        # benchmark data, not amplicon based
+        return False
+    sample = pep.sample_table.loc[sample]
     try:
         return bool(sample["is_amplicon_data"])
     except KeyError:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -179,7 +179,10 @@ def get_assembly_comparisons(bams=True):
             if bams
             else "resources/genomes/{accession}.fasta"
         )
-        return expand(pattern, accession=accessions,)
+        return expand(
+            pattern,
+            accession=accessions,
+        )
 
     return inner
 
@@ -286,7 +289,10 @@ def zip_expand(expand_string, zip_wildcard_1, zip_wildcard_2, expand_wildcard):
         [
             expand(ele, exp=expand_wildcard)
             for ele in expand(
-                expand_string, zip, zip1=zip_wildcard_1, zip2=zip_wildcard_2,
+                expand_string,
+                zip,
+                zip1=zip_wildcard_1,
+                zip2=zip_wildcard_2,
             )
         ],
         [],
@@ -305,6 +311,31 @@ def get_quast_fastas(wildcards):
 def get_strain(path_to_pangolin_call):
     pangolin_results = pd.read_csv(path_to_pangolin_call)
     return pangolin_results.loc[0]["lineage"]
+
+
+def is_amplicon_data(sample):
+    sample = samples.loc[sample]
+    try:
+        return bool(sample["is_amplicon_data"])
+    except KeyError:
+        return False
+
+
+def get_varlociraptor_bias_flags(wildcards):
+    if is_amplicon_data(wildcards.sample):
+        # no bias detection possible
+        return (
+            "--omit-strand-bias --omit-read-orientation-bias --omit-read-position-bias"
+        )
+    return ""
+
+
+def get_recal_input(wildcards):
+    if is_amplicon_data(wildcards.sample):
+        # do not mark duplicates
+        return "results/{date}/mapped/ref~{reference}/{sample}.bam"
+    # use BAM with marked duplicates
+    return "results/{date}/dedup/ref~{reference}/{sample}.bam"
 
 
 wildcard_constraints:

--- a/workflow/rules/read_mapping.smk
+++ b/workflow/rules/read_mapping.smk
@@ -76,7 +76,7 @@ rule mark_duplicates:
 
 rule samtools_calmd:
     input:
-        aln="results/{date}/dedup/ref~{reference}/{sample}.bam",
+        aln=get_recal_input,
         ref=get_reference(),
     output:
         "results/{date}/recal/ref~{reference}/{sample}.bam",

--- a/workflow/rules/read_trimming.smk
+++ b/workflow/rules/read_trimming.smk
@@ -14,7 +14,8 @@ rule fastp_pe:
         "logs/{date}/fastp/{sample}.log",
     params:
         # adapters=get_adapters,
-        adapters=config["adapters"]["illumina"],
+        # adapters=config["adapters"]["illumina-revelo"],
+        adapters=config["adapters"]["illumina-nimagen"],
         extra="--qualified_quality_phred {} ".format(
             config["RKI-quality-criteria"]["illumina"]["min-PHRED"]
         ) + "--length_required {}".format(

--- a/workflow/rules/variant_calling.smk
+++ b/workflow/rules/variant_calling.smk
@@ -58,6 +58,8 @@ rule varlociraptor_call:
         scenario="results/{date}/scenarios/{sample}.yaml",
     output:
         temp("results/{date}/calls/ref~{reference}/{sample}.bcf"),
+    params:
+        biases=get_varlociraptor_bias_flags,
     log:
         "logs/{date}/varlociraptor/call/ref~{reference}/{sample}.log",
     conda:

--- a/workflow/rules/variant_calling.smk
+++ b/workflow/rules/variant_calling.smk
@@ -66,5 +66,5 @@ rule varlociraptor_call:
         "../envs/varlociraptor.yaml"
     shell:
         "varlociraptor "
-        "call variants generic --obs {wildcards.sample}={input.obs} "
+        "call variants {params.biases} generic --obs {wildcards.sample}={input.obs} "
         "--scenario {input.scenario} > {output} 2> {log}"


### PR DESCRIPTION
It is now possible to define that a sample is amplicon data. In that case, valrociraptor will omit bias estimation and PCR deduplication is skipped.