### PR TITLE
Upload logs as artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,6 +185,12 @@ jobs:
         with:
           name: report-${{ matrix.rule }}
           path: .tests/report.zip
+          
+      - name: Upload logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: log-${{ matrix.rule }}
+          path: .tests/logs/
 
       # - name: Unit test
       #     args: "--generate-unit-tests"


### PR DESCRIPTION
This PR adds the log files from CI runs to the uploaded artifacts. This may be quite helpful for debugging. 