### PR TITLE
Workaround: explicitly add mkl as a dependency to the rbt env

### DIFF
--- a/workflow/envs/rbt.yaml
+++ b/workflow/envs/rbt.yaml
@@ -3,3 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - rust-bio-tools =0.20
+  - mkl # TODO without this dependency, we get "rbt: error while loading shared libraries: libmkl_rt.so: cannot open shared object file: No such file or directory" on some systems


### PR DESCRIPTION
@mbargull, do you have an idea why we need to do this? Seems like rbt was built on top of mkl, but on some systems a different (non-mkl) variant of openmp is chosen?