### PR TITLE
do not format numbers as strings in qc table

### DIFF
--- a/workflow/scripts/generate_virologist_output.py
+++ b/workflow/scripts/generate_virologist_output.py
@@ -18,8 +18,8 @@ for sample, file in zip(snakemake.params.samples, snakemake.input.reads_unfilter
     trimmed_reads = int(number_reads["summary"]["after_filtering"]["total_reads"])
     initial_reads_df = initial_reads_df.append(
         {
-            "# raw reads": f"{raw_reads:,}",
-            "# trimmed reads": f"{trimmed_reads:,}",
+            "# raw reads": raw_reads,
+            "# trimmed reads": trimmed_reads,
             "sample": sample,
         },
         ignore_index=True,
@@ -37,7 +37,7 @@ for sample, file in zip(snakemake.params.samples, snakemake.input.reads_used_for
             num_reads = 0
         filtered_reads_df = filtered_reads_df.append(
             {
-                "# used reads": f"{int(num_reads):,}",
+                "# used reads": int(num_reads),
                 "sample": sample,
             },
             ignore_index=True,
@@ -67,7 +67,7 @@ for sample, file in zip(snakemake.params.samples, snakemake.input.initial_contig
 
     initial_df = initial_df.append(
         {
-            "initial contig (bp)": f"{int(length_initial):,}",
+            "initial contig (bp)": int(length_initial),
             "sample": sample,
         },
         ignore_index=True,
@@ -89,7 +89,6 @@ for sample, file in zip(snakemake.params.samples, snakemake.input.polished_conti
 
     for key in contigs:
         length = len(contigs[key])
-    length = f'{length:,}'
     final_df = final_df.append(
         {
             "final contig (bp)": length,


### PR DESCRIPTION
We loose the histogram plotting ability in the HTML table then. Instead, we can add additional fancy int formatting in the table renderer.