### PR TITLE
Pin sample column of qc report

### DIFF
--- a/workflow/envs/rbt.yaml
+++ b/workflow/envs/rbt.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - rust-bio-tools =0.20
+  - rust-bio-tools =0.20.5

--- a/workflow/envs/rbt.yaml
+++ b/workflow/envs/rbt.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - rust-bio-tools =0.20.4
+  - rust-bio-tools =0.20

--- a/workflow/rules/generate_output.smk
+++ b/workflow/rules/generate_output.smk
@@ -174,10 +174,11 @@ rule qc_html_report:
         "../envs/rbt.yaml"
     params:
         formatter=get_resource("report-table-formatter.js"),
+        pin_until="sample",
     log:
         "logs/{date}/qc_report_html.log",
     shell:
-        "rbt csv-report {input} --formatter {params.formatter} {output} > {log} 2>&1"
+        "rbt csv-report {input} --formatter {params.formatter} --pin-until {params.pin_until} {output} > {log} 2>&1"
 
 
 rule snakemake_reports:


### PR DESCRIPTION
This PR pins the sample column of the qc report so that is always visible for the user. We need to have https://github.com/rust-bio/rust-bio-tools/pull/147 merged and released in order for this to work properly.