### PR TITLE
Fix downloading B117 reads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,8 +150,8 @@ jobs:
         if: steps.test-data.outputs.cache-hit != 'true' && startsWith(matrix.rule, 'all')
         run: |
           mkdir -p .tests/data
-          curl -L https://github.com/thomasbtf/small-kraken-db/blob/master/B.1.1.7.reads.1.fastq.gz > .tests/data/B117.1.fastq.gz
-          curl -L https://github.com/thomasbtf/small-kraken-db/blob/master/B.1.1.7.reads.1.fastq.gz > .tests/data/B117.2.fastq.gz
+          curl -L https://github.com/thomasbtf/small-kraken-db/raw/master/B.1.1.7.reads.1.fastq.gz > .tests/data/B117.1.fastq.gz
+          curl -L https://github.com/thomasbtf/small-kraken-db/raw/master/B.1.1.7.reads.1.fastq.gz > .tests/data/B117.2.fastq.gz
       
       - name: Use smaller reference files for testing
         if: steps.test-resources.outputs.cache-hit != 'true'


### PR DESCRIPTION
Just a quick fix to #137 which downloaded the GitHub html instead of the actual reads.