### PR TITLE
feat: add plot of variants over time

### DIFF
--- a/workflow/report/variants-over-time.rst
+++ b/workflow/report/variants-over-time.rst
@@ -1,0 +1,1 @@
+Development of variants over time. Low occurring variants are grouped together.

--- a/workflow/rules/generate_output.smk
+++ b/workflow/rules/generate_output.smk
@@ -182,9 +182,43 @@ rule plot_lineages_over_time:
         "../scripts/plot-lineages-over-time.py"
 
 
+rule plot_variants_over_time:
+    input:
+        bcf=lambda wildcards: expand(
+            "results/{date}/filtered-calls/ref~main/{sample}.subclonal.high+moderate-impact.bcf",
+            zip,
+            date=get_dates_before_date(wildcards),
+            sample=get_samples_before_date(wildcards),
+        ),
+        csi=lambda wildcards: expand(
+            "results/{date}/filtered-calls/ref~main/{sample}.subclonal.high+moderate-impact.bcf.csi",
+            zip,
+            date=get_dates_before_date(wildcards),
+            sample=get_samples_before_date(wildcards),
+        ),
+    output:
+        report(
+            "results/{date}/plots/variants-over-time.svg",
+            caption="../report/variants-over-time.rst",
+            category="1. Overview",
+            subcategory="3. Variant Development",
+        ),
+        "results/{date}/tables/variants-over-time.csv",
+    params:
+        dates=get_dates_before_date,
+        samples=get_samples_before_date,
+    log:
+        "logs/{date}/plot_variants_over_time.log",
+    conda:
+        "../envs/python.yaml"
+    script:
+        "../scripts/plot-variants-over-time.py"
+
+
 rule snakemake_reports:
     input:
         "results/{date}/plots/lineages-over-time.svg",
+        "results/{date}/plots/variants-over-time.svg",
         "results/{date}/plots/coverage-reference-genome.svg",
         "results/{date}/plots/coverage-assembled-genome.svg",
         lambda wildcards: expand(

--- a/workflow/rules/strain_calling.smk
+++ b/workflow/rules/strain_calling.smk
@@ -82,7 +82,7 @@ rule plot_strains_kallisto:
             "results/{date}/plots/strain-calls/{sample}.strains.kallisto.svg",
             caption="../report/strain-calls-kallisto.rst",
             category="1. Overview",
-            subcategory="4. Lineage Fraction per Sample",
+            subcategory="5. Lineage Fraction per Sample",
         ),
     log:
         "logs/{date}/plot-strains-kallisto/{sample}.log",
@@ -105,7 +105,7 @@ rule plot_all_strains_kallisto:
             "results/{date}/plots/all.{mode,(major|any)}-strain.strains.kallisto.svg",
             caption="../report/all-strain-calls-kallisto.rst",
             category="1. Overview",
-            subcategory="3. Strain Calls",
+            subcategory="4. Strain Calls",
         ),
     log:
         "logs/{date}/plot-strains/all.{mode}.log",
@@ -144,7 +144,7 @@ rule plot_all_strains_pangolin:
             "results/{date}/plots/all.strains.pangolin.svg",
             caption="../report/all-strain-calls-pangolin.rst",
             category="1. Overview",
-            subcategory="3. Strain Calls",
+            subcategory="4. Strain Calls",
         ),
     log:
         "logs/{date}/plot-strains-pangolin/all.log",

--- a/workflow/scripts/plot-variants-over-time.py
+++ b/workflow/scripts/plot-variants-over-time.py
@@ -73,7 +73,7 @@ def plot_variants_over_time(sm_output, sm_output_table):
         "alteration"
     ].transform(lambda s: s.count())
 
-    # # mask low occurrences
+    # mask low occurrences
     calls.loc[calls["total occurrence"] < 10, "alteration"] = "other (< 10 occ.)"
 
     calls.rename(columns={"alteration": "Alteration", "date": "Date"}, inplace=True)
@@ -99,6 +99,5 @@ def plot_variants_over_time(sm_output, sm_output_table):
     ).properties(width=800)
 
     area_plot.save(sm_output)
-
 
 plot_variants_over_time(snakemake.output[0], snakemake.output[1])

--- a/workflow/scripts/plot-variants-over-time.py
+++ b/workflow/scripts/plot-variants-over-time.py
@@ -29,9 +29,12 @@ AA_ALPHABET_TRANSLATION = {
     "Thr": "T",
 }
 
+
 def get_calls():
     variants = []
-    for file, date, sample in zip(snakemake.input.bcf, snakemake.params.dates, snakemake.params.samples):
+    for file, date, sample in zip(
+        snakemake.input.bcf, snakemake.params.dates, snakemake.params.samples
+    ):
         with pysam.VariantFile(file, "rb") as infile:
             for record in infile:
                 vaf = record.samples[0]["AF"][0]
@@ -49,14 +52,15 @@ def get_calls():
 
                         variants.append(
                             {
-                                "feature" : feature,
-                                "alteration" : alteration,
+                                "feature": feature,
+                                "alteration": alteration,
                                 "vaf": vaf,
-                                "date" : date,
-                                "sample" : sample
+                                "date": date,
+                                "sample": sample,
                             }
                         )
     return pd.DataFrame(variants)
+
 
 def plot_variants_over_time(sm_output, sm_output_table):
     calls = get_calls()
@@ -68,11 +72,9 @@ def plot_variants_over_time(sm_output, sm_output_table):
     calls["total occurrence"] = calls.groupby("alteration", as_index=False)[
         "alteration"
     ].transform(lambda s: s.count())
-    
+
     # # mask low occurrences
-    calls.loc[
-        calls["total occurrence"] < 10, "alteration"
-    ] = "other (< 10 occ.)"
+    calls.loc[calls["total occurrence"] < 10, "alteration"] = "other (< 10 occ.)"
 
     calls.rename(columns={"alteration": "Alteration", "date": "Date"}, inplace=True)
 
@@ -99,6 +101,4 @@ def plot_variants_over_time(sm_output, sm_output_table):
     area_plot.save(sm_output)
 
 
-plot_variants_over_time(
-    snakemake.output[0], snakemake.output[1]
-)
+plot_variants_over_time(snakemake.output[0], snakemake.output[1])

--- a/workflow/scripts/plot-variants-over-time.py
+++ b/workflow/scripts/plot-variants-over-time.py
@@ -1,0 +1,104 @@
+import sys
+
+sys.stderr = open(snakemake.log[0], "w")
+
+import altair as alt
+import pandas as pd
+import pysam
+
+AA_ALPHABET_TRANSLATION = {
+    "Gly": "G",
+    "Ala": "A",
+    "Leu": "L",
+    "Met": "M",
+    "Phe": "F",
+    "Trp": "W",
+    "Lys": "K",
+    "Gln": "Q",
+    "Glu": "E",
+    "Ser": "S",
+    "Pro": "P",
+    "Val": "V",
+    "Ile": "I",
+    "Cys": "C",
+    "Tyr": "Y",
+    "His": "H",
+    "Arg": "R",
+    "Asn": "N",
+    "Asp": "D",
+    "Thr": "T",
+}
+
+def get_calls():
+    variants = []
+    for file, date, sample in zip(snakemake.input.bcf, snakemake.params.dates, snakemake.params.samples):
+        with pysam.VariantFile(file, "rb") as infile:
+            for record in infile:
+                vaf = record.samples[0]["AF"][0]
+                for ann in record.info["ANN"]:
+                    ann = ann.split("|")
+                    hgvsp = ann[11]
+                    enssast_id = ann[6]
+                    feature = ann[3]
+                    if hgvsp:
+                        # TODO think about regex instead of splitting
+                        enssast_id, alteration = hgvsp.split(":", 1)
+                        _prefix, alteration = alteration.split(".", 1)
+                        for triplet, amino in AA_ALPHABET_TRANSLATION.items():
+                            alteration = alteration.replace(triplet, amino)
+
+                        variants.append(
+                            {
+                                "feature" : feature,
+                                "alteration" : alteration,
+                                "vaf": vaf,
+                                "date" : date,
+                                "sample" : sample
+                            }
+                        )
+    return pd.DataFrame(variants)
+
+def plot_variants_over_time(sm_output, sm_output_table):
+    calls = get_calls()
+
+    # write out as table
+    calls.to_csv(sm_output_table)
+
+    # get occurrences
+    calls["total occurrence"] = calls.groupby("alteration", as_index=False)[
+        "alteration"
+    ].transform(lambda s: s.count())
+    
+    # # mask low occurrences
+    calls.loc[
+        calls["total occurrence"] < 10, "alteration"
+    ] = "other (< 10 occ.)"
+
+    calls.rename(columns={"alteration": "Alteration", "date": "Date"}, inplace=True)
+
+    area_plot = (
+        alt.Chart(calls)
+        .mark_bar(opacity=0.8)
+        .encode(
+            x=alt.X("Date:O"),
+            y=alt.Y(
+                "count()",
+                stack="normalize",
+                axis=alt.Axis(format="%"),
+                title="Fraction in Run",
+            ),
+            stroke="Alteration",
+            color=alt.Color(
+                "Alteration",
+                scale=alt.Scale(scheme="tableau10"),
+                legend=alt.Legend(orient="top"),
+            ),
+        )
+    ).properties(width=800)
+
+    area_plot.save(sm_output)
+
+
+plot_variants_over_time(
+    snakemake.output[0], snakemake.output[1]
+)


### PR DESCRIPTION
![variants-over-time](https://user-images.githubusercontent.com/46334240/134577880-16e5578a-8318-47ba-9366-9065b90d394c.jpg)

TODO: We have to how to aggregate the variants. There are too many to display them, especially if the plot should help to detect new genomic variants that become gradually more abundant over time. Maybe can also work with the ORFS for a better overview. Any thoughts?


<details><summary>Expected commit message structure</summary>

Commit messages (in particular the merge commit of a pull request) should be structured as follows:

```
<type>[optional scope]: <description>

[optional body]

[optional footer]
```

The commit contains the following structural elements, to communicate intent to the consumers of your library:

- `fix:` a commit of the *type* `fix` patches a bug in your codebase (this correlates with `PATCH` in semantic versioning).
- `feat:` a commit of the *type* `feat` introduces a new feature to the codebase (this correlates with `MINOR` in semantic versioning).
- `BREAKING CHANGE:` a commit that has the text `BREAKING CHANGE`: at the beginning of its optional body or footer section introduces a breaking API change (correlating with `MAJOR` in semantic versioning). A breaking change can be part of commits of any type. e.g., a `fix:`, `feat:` & `chore:` types would all be valid, in addition to any other type.
- Others: commit types other than `fix:` and feat: are allowed, for example 
    - `chore:`
    - `docs:`
    - `style:`
    - `refactor:`
    - `perf:`
    - `test:`
    
    and others. We also recommend improvement for commits that improve a current implementation without adding a new feature or fixing a bug. Notice these types are not mandated by the conventional commits specification, and have no implicit effect in semantic versioning (unless they include a `BREAKING CHANGE`, which is NOT recommended). A scope may be provided to a commit’s type, to provide additional contextual information and is contained within parenthesis, e.g., `feat(parser): add ability to parse arrays`.

## Examples

Commit message with description and breaking change in body
```
feat: allow provided config object to extend other configs

BREAKING CHANGE: `extends` key in config file is now used for extending other config files
```

Commit message with no body
```
docs: correct spelling of CHANGELOG
````

Commit message with scope
```
feat(lang): added polish language
```

Commit message for a fix using an (optional) issue number.
```
fix: minor typos in code

see the issue for details on the typos fixed

fixes issue #12
```

</p>
</details>
